### PR TITLE
Acs make scope optional

### DIFF
--- a/docs/modules/ROOT/pages/abac.adoc
+++ b/docs/modules/ROOT/pages/abac.adoc
@@ -93,11 +93,7 @@ as demanding such evaluation would require a replication of this functionality a
   - id         ex: urn:oasis:names:tc:xacml:1.0:subject:subject-id
   - value      ex: <subject identifier>
 
-  # To identify role scoping entity
-  - id         ex: urn:restorecommerce:acs:names:roleScopingEntity
-  - value      ex: urn:restorecommerce:acs:model:organization.Organization
-
-  # To identify role scoping instance
+  # To identify role scoping instance (optional)
   - id         ex: urn:restorecommerce:acs:names:roleScopeInstance
     value:     ex: <organization identifier>
 - resources
@@ -190,10 +186,6 @@ request:
     subjects:
       - id: ex: urn:oasis:names:tc:xacml:1.0:subject:subject-id
         value: Alice
-      - id: urn:restorecommerce:acs:names:roleScopingEntity
-        value: urn:restorecommerce:acs:model:organization.Organization
-      - id: urn:restorecommerce:acs:names:roleScopeInstance
-        value: OrgB
     resources:
       - id: urn:restorecommerce:acs:names:model:entity
         value: urn:restorecommerce:model:device.Device
@@ -283,7 +275,8 @@ which according to the policy's combining algorithm means access should be grant
 
 The operation `whatIsAllowed` is used when there is not a specific target resource for a request, for example, when Subject aims to see as much resources as possible.
 This example illustrates permissible actions on two resource entities `Address` and `Country` for Subject `Alice` who has the role `admin` within the scoping entity
-`Organization` with ID 'OrgA'.
+`Organization` with ID 'OrgA'. The target role scoping instance in subjects below `OrgA` is optional for `whatIsAllowed`, if it is provided then filters are created by https://github.com/restorecommerce/libs/tree/next/packages/acs-client[`acs-client`] based on
+this target role scope instance if not all applicable filters are returned from `acs-client` 
 
 [source,yml]
 ----
@@ -292,8 +285,6 @@ request:
       subjects:
         - id: ex: urn:oasis:names:tc:xacml:1.0:subject:subject-id
           value: Alice
-        - id: urn:restorecommerce:acs:names:roleScopingEntity
-          value: urn:restorecommerce:acs:model:organization.Organization
         - id: urn:restorecommerce:acs:names:roleScopeInstance
           value: OrgA
       resources:
@@ -394,8 +385,6 @@ request:
     subjects:
       - id: ex: urn:oasis:names:tc:xacml:1.0:subject:subject-id
         value: Alice
-      - id: urn:restorecommerce:acs:names:roleScopingEntity
-        value: urn:restorecommerce:acs:model:organization.Organization
       - id: urn:restorecommerce:acs:names:roleScopeInstance
         value: OrgA
     resources:

--- a/src/core/accessController.ts
+++ b/src/core/accessController.ts
@@ -776,7 +776,7 @@ export class AccessController {
     // Just check the Role value matches here in subject
     const roleURN = this.urns.get('role');
     let ruleRole: string;
-    if (ruleSubAttributes?.length === 0) {
+    if (!ruleSubAttributes || ruleSubAttributes.length === 0) {
       return true;
     }
     ruleSubAttributes?.forEach((subjectObject) => {
@@ -792,10 +792,14 @@ export class AccessController {
     }
 
     if(!ruleRole) {
-      this.logger.warn('Invalid Rule as Rule Subject attributes array contains other id, value pairs without role', ruleSubAttributes);
+      this.logger.warn(`Subject does not match with rule attributes`, ruleSubAttributes);
       return false;
     }
     const context = (request as any)?.context as ContextWithSubResolved;
+    if(!context?.subject?.role_associations) {
+      this.logger.warn('Subject role associations missing', ruleSubAttributes);
+      return false;
+    }
     return context?.subject?.role_associations?.some((roleObj) => roleObj?.role === ruleRole);
   }
 

--- a/src/core/accessController.ts
+++ b/src/core/accessController.ts
@@ -803,21 +803,6 @@ export class AccessController {
     return context?.subject?.role_associations?.some((roleObj) => roleObj?.role === ruleRole);
   }
 
-  private checkTargetInstanceExists(hrScope: HierarchicalScope,
-    targetScopingInstance: string): boolean {
-    if (hrScope?.id === targetScopingInstance) {
-      return true;
-    } else {
-      if (hrScope?.children?.length > 0) {
-        for (let child of hrScope.children) {
-          if (this.checkTargetInstanceExists(child, targetScopingInstance)) {
-            return true;
-          }
-        }
-      }
-    }
-  }
-
   /**
    * A list of rules or policies provides a list of Effects.
    * This method is invoked to evaluate the final effect

--- a/src/core/hierarchicalScope.ts
+++ b/src/core/hierarchicalScope.ts
@@ -193,20 +193,20 @@ export const checkHierarchicalScope = async (ruleTarget: Target,
     const reducedHRScopes = context?.subject?.hierarchical_scopes?.filter((hrObj) => hrObj?.role === ruleRole);
     for (let [resourceId, owners] of resourceIdOwnersMap) {
       // validate scoping Entity first
-      let ownerInstance: string;
+      let ownerInstances: string[] = [];
       const entityMatch = owners?.some((ownerObj) => {
         return reducedUserRoleAssocs?.some((roleObj) => {
           if (roleObj?.attributes?.some((roleAttributeObject) => roleAttributeObject?.id === urns.get('roleScopingEntity')
             && ownerObj?.id === urns.get('ownerEntity') && ownerObj.value === ruleRoleScopingEntity && ownerObj.value === roleAttributeObject?.value)) {
-            ownerObj?.attributes?.forEach((obj) => ownerInstance = obj.value);
+            ownerObj?.attributes?.forEach((obj) => ownerInstances.push(obj.value));
             return true;
           }
         });
       });
       // validate the ownerInstance from HR scope tree for matched scoping entity
-      if (entityMatch && ownerInstance) {
+      if (entityMatch && ownerInstances?.length > 0) {
         traverse(reducedHRScopes).forEach((node: any) => { // depth-first search
-          if (node?.id === ownerInstance) {
+          if (ownerInstances.includes(node?.id)) {
             deleteMapEntries.push(resourceId);
           }
         });

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -422,25 +422,3 @@ export const flushACSCache = async (userId: string, db_index, commandTopic: Topi
   await commandTopic.emit('flushCacheCommand', eventObject);
   logger.info('ACS flush cache command event emitted to kafka topic successfully');
 };
-
-export const updateScopedRoles = (meta, scopedRoles, urns: Map<string, string>, totalScopingEntities: string[]): Map<string, Map<string, string[]>> => {
-  meta.owners.filter((owner) => owner.id === urns.get('ownerEntity') && _.find(totalScopingEntities, e => e === owner.value)).forEach(
-    (owner) => {
-      let ownerEntity = owner.value;
-      owner.attributes.filter(((ownerInstObj) => ownerInstObj.id == urns.get('ownerInstance') && !!ownerEntity)).forEach(
-        (ownerInstObj) => {
-          scopedRoles.forEach((entities, role) => {
-            if (entities.has(ownerEntity)) {
-              const instances = entities.get(ownerEntity);
-              instances.push(ownerInstObj.value);
-              entities.set(ownerEntity, instances);
-              scopedRoles.set(role, entities);
-            }
-          });
-          ownerEntity = null;
-        }
-      );
-    }
-  );
-  return scopedRoles;
-};

--- a/test/core.spec.ts
+++ b/test/core.spec.ts
@@ -526,7 +526,8 @@ describe('Testing access control core', () => {
         ownerIndicatoryEntity: 'urn:restorecommerce:acs:model:organization.Organization',
         ownerInstance: 'Org1'
       });
-
+      // set HR scope for Org2 (since target scope is no longer used since matching is done based on owners with roleAssocs)
+      (request.context.subject as any).hierarchical_scopes = [{ "id": "Org2", "children": [{ "id": "Org3" }] }];
       await requestAndValidate(ac, request, Response_Decision.DENY);
     });
     it('should PERMIT Execute action on executeTestMutation by an Admin', async () => {

--- a/test/core.spec.ts
+++ b/test/core.spec.ts
@@ -368,6 +368,38 @@ describe('Testing access control core', () => {
       await requestAndValidate(ac, request, Response_Decision.PERMIT);
     });
 
+    it('should INDETERMINATE based on rule R6 as subject HR scope does not match', async () => {
+      request = testUtils.buildRequest({
+        subjectID: 'Alice',
+        subjectRole: 'SimpleUser',
+        roleScopingEntity: 'urn:restorecommerce:acs:model:organization.Organization',
+        roleScopingInstance: 'Org1',
+        resourceType: 'urn:restorecommerce:acs:model:location.Location',
+        resourceID: 'Random',
+        actionType: 'urn:restorecommerce:acs:names:action:modify',
+        ownerIndicatoryEntity: 'urn:restorecommerce:acs:model:organization.Organization',
+        ownerInstance: 'Org4' // does not exist in HR scope
+      });
+
+      await requestAndValidate(ac, request, Response_Decision.INDETERMINATE);
+    });
+
+    it('should PERMIT based on rule R6 as subject HR scope matches', async () => {
+      request = testUtils.buildRequest({
+        subjectID: 'Alice',
+        subjectRole: 'SimpleUser',
+        roleScopingEntity: 'urn:restorecommerce:acs:model:organization.Organization',
+        roleScopingInstance: 'Org1',
+        resourceType: 'urn:restorecommerce:acs:model:location.Location',
+        resourceID: 'Random',
+        actionType: 'urn:restorecommerce:acs:names:action:modify',
+        ownerIndicatoryEntity: 'urn:restorecommerce:acs:model:organization.Organization',
+        ownerInstance: 'Org2' // exist in HR scope
+      });
+
+      await requestAndValidate(ac, request, Response_Decision.PERMIT);
+    });
+
     it('should DENY based on Rule BA2', async () => {
       request = testUtils.buildRequest({
         subjectID: 'External Bob',

--- a/test/fixtures/conditions.yml
+++ b/test/fixtures/conditions.yml
@@ -51,11 +51,8 @@ policy_sets:
                 }) != null;"
           - id: ruleAA3
             name: Rule AA3
-            descripton: A rule targeting a user's 'modify' permission regarding a User account
+            descripton: A fallback rule targeting a user's 'modify' permission regarding a User account
             target:
-              subjects:
-                - id: urn:restorecommerce:acs:names:role
-                  value: SimpleUser
               resources:
                 - id: urn:restorecommerce:acs:names:model:entity
                   value: urn:restorecommerce:acs:model:user.User

--- a/test/fixtures/policy_sets_with_targets.yml
+++ b/test/fixtures/policy_sets_with_targets.yml
@@ -80,3 +80,30 @@ policy_sets:
                 - id: urn:oasis:names:tc:xacml:1.0:action:action-id
                   value: urn:restorecommerce:acs:names:action:read
             effect: PERMIT
+  - id: PS3
+    name: 'Policy set C'
+    description: 'A policy set targeting Org scoping with Subject scoping defined on Policy level instead of Rule'
+    combining_algorithm: urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:permit-overrides      
+    policies:
+      - id: P3
+        name: Policy with Org Scoping for Location Resource
+        description: A Policy targeting access for Org scope users for Location resource
+        combining_algorithm: urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:permit-overrides
+        target:
+          subjects:
+            - id: urn:restorecommerce:acs:names:role
+              value: SimpleUser
+            - id: urn:restorecommerce:acs:names:roleScopingEntity
+              value: urn:restorecommerce:acs:model:organization.Organization
+          resources:
+            - id: urn:restorecommerce:acs:names:model:entity
+              value: urn:restorecommerce:acs:model:location.Location
+        rules:
+          - id: R6
+            name: Rule 5
+            description: A rule targeting 'modify' actions on Location resource
+            target:
+              actions:
+                - id: urn:oasis:names:tc:xacml:1.0:action:action-id
+                  value: urn:restorecommerce:acs:names:action:modify
+            effect: PERMIT

--- a/test/microservice_acs_enabled.spec.ts
+++ b/test/microservice_acs_enabled.spec.ts
@@ -956,7 +956,7 @@ describe('testing microservice', () => {
       });
 
        // Create with two different scopes assigned for same role
-       it('should PERMIT to create test rule with ACS enabled without providing scope in subject with multilple instances assigned to same role', async () => {
+       it('should PERMIT to create test rule with ACS enabled with multiple owners without providing scope in subject with multilple instances assigned to same role', async () => {
         let testRule1 = [{
           name: '1 test rule for test entitiy',
           description: '1 test rule',
@@ -978,6 +978,12 @@ describe('testing microservice', () => {
               attributes: [{
                 id: 'urn:restorecommerce:acs:names:ownerInstance',
                 value: 'org1'
+              }, {
+                id: 'urn:restorecommerce:acs:names:ownerInstance',
+                value: 'org2'
+              }, {
+                id: 'urn:restorecommerce:acs:names:ownerInstance',
+                value: 'org3'
               }]
             }]
           }
@@ -1031,7 +1037,13 @@ describe('testing microservice', () => {
               value: 'urn:restorecommerce:acs:model:organization.Organization',
               attributes: [{
                 id: 'urn:restorecommerce:acs:names:ownerInstance',
+                value: 'org1'
+              }, {
+                id: 'urn:restorecommerce:acs:names:ownerInstance',
                 value: 'org2'
+              }, {
+                id: 'urn:restorecommerce:acs:names:ownerInstance',
+                value: 'org3'
               }]
             }]
           }

--- a/test/properties.spec.ts
+++ b/test/properties.spec.ts
@@ -158,6 +158,7 @@ describe('testing access control', () => {
         ownerIndicatoryEntity: 'urn:restorecommerce:acs:model:organization.Organization',
         ownerInstance: ['Org1', 'Org1']
       });
+      (accessRequest.context.subject as any).hierarchical_scopes = [{ id: 'Org3', children: [] }];
       testUtils.marshallRequest(accessRequest);
 
       const result = await accessControlService.isAllowed(accessRequest);

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -37,20 +37,6 @@ export const buildRequest = (opts: RequestOpts): Request => {
     }
   ]);
 
-  if (opts.roleScopingEntity && opts.roleScopingInstance) {
-    subjects = subjects.concat([
-      {
-        id: 'urn:restorecommerce:acs:names:roleScopingEntity',
-        value: opts.roleScopingEntity,
-        attributes: [{
-          id: 'urn:restorecommerce:acs:names:roleScopingInstance',
-          value: opts.targetScopingInstance ? opts.targetScopingInstance : opts.roleScopingInstance,
-          attributes: []
-        }]
-      }
-    ]);
-  }
-
   if (opts.actionType === 'urn:restorecommerce:acs:names:action:execute') {
     if (typeof opts.resourceType === 'string') {
       resources = resources.concat([


### PR DESCRIPTION
* Scoping entity is now redundant for both isAllowed and whatIsAllowed and hence is removed from request for both isAllowed and whatIsAllowed operations.
* Target scope is not needed for isAllowed and is optional for whatIsAllowed (as it might be necessary to narrow down filters from HR scope for read operations)